### PR TITLE
Dev jennifer

### DIFF
--- a/configs/atlas.config
+++ b/configs/atlas.config
@@ -5,6 +5,7 @@
 process {
   executor = 'slurm'
   clusterOptions =  '-N 1 -n 16 -t 02:00:00 --account=isu_gif_vrsc'
+  //clusterOptions =  "-N 1 -n 16 -t 02:00:00 ${env.account_flag}"
   scratch=true
 
   /* Placeholder till we can add custom cluster configuration here

--- a/configs/atlas.config
+++ b/configs/atlas.config
@@ -7,4 +7,24 @@ process {
   clusterOptions =  '-N 1 -n 16 -t 02:00:00 --account=isu_gif_vrsc'
   scratch=true
 
+  /* Placeholder till we can add custom cluster configuration here
+  withName:get_test_data { }
+  withName:fasta_sort { }
+  withName:fasta_bwa_index { }
+  withName:fasta_samtools_faidx { }
+  withName:fasta_picard_dict { }
+  withName:paired_FastqToSAM { }
+  withName:BAM_MarkIlluminaAdapters { }
+  withName:BAM_SamToFastq { }
+  withName:run_bwa_mem { }
+  withName:run_MergeBamAlignment { }
+  withName:fai_bedtools_makewindows { }
+  withName:run_gatk_snp { }
+  withName:merge_vcf { }
+  withName:vcftools_snp_only { }
+  withName:run_SortVCF { }
+  withName:calc_DPvalue { }
+  withName:gatk_VariantFiltration { }
+  withName:keep_only_pass { }
+  */
 }

--- a/configs/ceres.config
+++ b/configs/ceres.config
@@ -6,4 +6,25 @@ process {
   executor = 'slurm'
   clusterOptions =  "-N 1 -n 16 -t 02:00:00 $account_flag"
   scratch=true
+
+  /* Placeholder till we can add custom cluster configuration here
+  withName:get_test_data { }
+  withName:fasta_sort { }
+  withName:fasta_bwa_index { }
+  withName:fasta_samtools_faidx { }
+  withName:fasta_picard_dict { }
+  withName:paired_FastqToSAM { }
+  withName:BAM_MarkIlluminaAdapters { }
+  withName:BAM_SamToFastq { }
+  withName:run_bwa_mem { }
+  withName:run_MergeBamAlignment { }
+  withName:fai_bedtools_makewindows { }
+  withName:run_gatk_snp { clusterOptions =  "-N 1 -n 16 -t 02:00:00 $account_flag" }
+  withName:merge_vcf { }
+  withName:vcftools_snp_only { }
+  withName:run_SortVCF { }
+  withName:calc_DPvalue { }
+  withName:gatk_VariantFiltration { }
+  withName:keep_only_pass { }
+  */
 }

--- a/configs/ceres.config
+++ b/configs/ceres.config
@@ -4,7 +4,7 @@
 
 process {
   executor = 'slurm'
-  clusterOptions =  "-N 1 -n 16 -t 02:00:00 $account_flag"
+  clusterOptions =  "-N 1 -n 16 -t 02:00:00 ${env.account_flag}"
   scratch=true
 
   /* Placeholder till we can add custom cluster configuration here

--- a/configs/ceres.config
+++ b/configs/ceres.config
@@ -1,0 +1,9 @@
+/*****************************
+ Configuration for any slurm job
+ *****************************/
+
+process {
+  executor = 'slurm'
+  clusterOptions =  "-N 1 -n 16 -t 02:00:00 --account=$account_hpc"
+  scratch=true
+}

--- a/configs/ceres.config
+++ b/configs/ceres.config
@@ -4,6 +4,6 @@
 
 process {
   executor = 'slurm'
-  clusterOptions =  "-N 1 -n 16 -t 02:00:00 --account=$account_hpc"
+  clusterOptions =  "-N 1 -n 16 -t 02:00:00 $account_flag"
   scratch=true
 }

--- a/configs/custom.config
+++ b/configs/custom.config
@@ -4,22 +4,22 @@
 /* https://www.nextflow.io/docs/latest/config.html?highlight=environment */
 
 process {
-  withName:get_test_data { }
-  withName:fasta_sort { }
-  withName:fasta_bwa_index { }
-  withName:fasta_samtools_faidx { }
-  withName:fasta_picard_dict { }
-  withName:paired_FastqToSAM { }
-  withName:BAM_MarkIlluminaAdapters { }
-  withName:BAM_SamToFastq { }
-  withName:run_bwa_mem { }
-  withName:run_MergeBamAlignment { }
-  withName:fai_bedtools_makewindows { }
-  withName:run_gatk_snp { }
-  withName:merge_vcf { }
-  withName:vcftools_snp_only { }
-  withName:run_SortVCF { }
-  withName:calc_DPvalue { }
-  withName:gatk_VariantFiltration { }
-  withName:keep_only_pass { }
+  // withName:get_test_data { }
+  // withName:fasta_sort { }
+  // withName:fasta_bwa_index { }
+  // withName:fasta_samtools_faidx { }
+  // withName:fasta_picard_dict { }
+  // withName:paired_FastqToSAM { }
+  // withName:BAM_MarkIlluminaAdapters { }
+  // withName:BAM_SamToFastq { }
+  // withName:run_bwa_mem { }
+  // withName:run_MergeBamAlignment { }
+  // withName:fai_bedtools_makewindows { }
+  // withName:run_gatk_snp { }
+  // withName:merge_vcf { }
+  // withName:vcftools_snp_only { }
+  // withName:run_SortVCF { }
+  // withName:calc_DPvalue { }
+  // withName:gatk_VariantFiltration { }
+  // withName:keep_only_pass { }
 }

--- a/configs/slurm.config
+++ b/configs/slurm.config
@@ -4,7 +4,7 @@
 
 process {
   executor = 'slurm'
-  clusterOptions =  '-N 1 -n 16 -t 02:00:00 $account_flag'
+  clusterOptions =  "-N 1 -n 16 -t 02:00:00 ${env.account_flag}"
   scratch=true
 
 //  Probably want to add small, medium and large memory configuration here

--- a/configs/slurm.config
+++ b/configs/slurm.config
@@ -4,7 +4,7 @@
 
 process {
   executor = 'slurm'
-  clusterOptions =  '-N 1 -n 16 -t 02:00:00'
+  clusterOptions =  '-N 1 -n 16 -t 02:00:00 $account_flag'
   scratch=true
 
 //  Probably want to add small, medium and large memory configuration here

--- a/main.nf
+++ b/main.nf
@@ -31,7 +31,9 @@ def helpMsg() {
    Optional other arguments:
     --window                Window size passed to bedtools for gatk [default:100000]
     --queueSize             Maximum jobs to submit to slurm [default:18]
+    --account               HPC account name for slurm sbatch, atlas and ceres requires this
     --help
+    
 """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
 
   // Reference genome to map against when looking for SNPs
   genome = false
-  
+
   // Either input reads as a glob pattern or as a tab delimited file
   reads = false
   reads_file = false
@@ -21,7 +21,7 @@ params {
 
   window = 100000
   queueSize = 20
-  account = false
+  account = false   // HPC account name
   singularity_img = 'shub://aseetharam/gatk:latest'
 
   // optional: manually link executables
@@ -80,7 +80,7 @@ profiles {
     includeConfig 'configs/slurm.config'
     includeConfig 'configs/condo.config'
   }
-  
+
   atlas {
     includeConfig 'configs/atlas.config'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,9 +42,9 @@ env {
   gatk_app = "$params.gatk_app"
   datamash_app = "$params.datamash_app"
   vcftools_app = "$params.vcftools_app"
-  // ?: is called an Elvis assignment operator
-  // params.account must not be in "" or it will convert 'false' to string"
-  account_flag = params.account ? " --account $params.account " : ''
+  // questionmark colon is called an Elvis assignment operator
+  // params account must not be in "" or it will convert 'false' to string"
+  account_flag = params.account ? " --account $params.account " : ' '
 }
 
 /****************************

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,3 @@
-
 /****************************
  Default parameter values
  nextflow run script.nf --genome "./test-data/ref/*.fasta"
@@ -21,7 +20,7 @@ params {
 
   window = 100000
   queueSize = 20
-  
+  account = false
   singularity_img = 'shub://aseetharam/gatk:latest'
 
   // optional: manually link executables
@@ -43,6 +42,7 @@ env {
   gatk_app = "$params.gatk_app"
   datamash_app = "$params.datamash_app"
   vcftools_app = "$params.vcftools_app"
+  account_hpc = "$params.account"
 }
 
 /****************************
@@ -81,6 +81,10 @@ profiles {
   
   atlas {
     includeConfig 'configs/atlas.config'
+  }
+
+  ceres {
+    includeConfig 'configs/ceres.config'
   }
 
   docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,4 @@
+
 /****************************
  Default parameter values
  nextflow run script.nf --genome "./test-data/ref/*.fasta"
@@ -31,7 +32,6 @@ params {
   gatk_app = 'gatk'
   datamash_app = 'datamash'
   vcftools_app = 'vcftools'
-
 }
 
 env {
@@ -42,7 +42,9 @@ env {
   gatk_app = "$params.gatk_app"
   datamash_app = "$params.datamash_app"
   vcftools_app = "$params.vcftools_app"
-  account_hpc = "$params.account"
+  // ?: is called an Elvis assignment operator
+  // params.account must not be in "" or it will convert 'false' to string"
+  account_flag = params.account ? " --account $params.account " : ''
 }
 
 /****************************

--- a/submit_nf.slurm
+++ b/submit_nf.slurm
@@ -8,7 +8,7 @@
 # --mail-user=username@email.com
 # --mail-type=begin
 # --mail-type=end
-# --account=isu_gif_vrsc
+# --account=isu_gif_vrsc    # <= put HPC account name here, required on Atlas and Ceres
 
 set -e
 set -u


### PR DESCRIPTION
Add `--account` option for Ceres and Atlas HPC

example:

```
nextflow run main.nf \
  --genome test-data/ref/b73_chr1_150000001-151000000.fasta \
  --reads "test-data/fastq/*_{R1,R2}.fastq.gz" \
  -profile slurm,singularity \
  --account PROJECT_NAME_HERE \
  -resume
```

which submits slurm jobs with options

```
clusterOptions =  '-N 1 -n 16 -t 02:00:00 --account=PROJECT_NAME_HERE'
```