### PR TITLE
Refactor nextflow code style

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -21,19 +21,20 @@ def helpMsg() {
    Optional configuration arguments:
     -profile                Configuration profile to use. Can use multiple (comma separated)
                             Available: local, slurm, singularity, docker [default:local]
-    --singularity_img       Singularity image if [-profile singularity] is set [default:'shub://aseetharam/gatk:latest']
-    --docker_img            Docker image if [-profile docker] is set [default:'j23414/gatk4']
-    --gatk_app              Link to gatk executable [default: 'gatk']
-    --bwamem2_app           Link to bwamem2 executable [default: 'bwa-mem2']
-    --samtools_app          Link to samtools executable [default: 'samtools']
-    --bedtools_app          Link to bedtools executable [default: 'bedtools']
-    --datamash_app          Link to datamash executable [default: 'datamash']
-    --vcftools_app          Link to vcftools executable [default: 'vcftools']
+    --singularity_img       Singularity image if [-profile singularity] is set [default:'${params.singularity_img}']
+    --docker_img            Docker image if [-profile docker] is set [default:'${params.docker_img}']
+    --gatk_app              Link to gatk executable [default: '$gatk_app']
+    --bwamem2_app           Link to bwamem2 executable [default: '$bwamem2_app']
+    --samtools_app          Link to samtools executable [default: '$samtools_app']
+    --bedtools_app          Link to bedtools executable [default: '$bedtools_app']
+    --datamash_app          Link to datamash executable [default: '$datamash_app']
+    --vcftools_app          Link to vcftools executable [default: '$vcftools_app']
 
    Optional other arguments:
+    --java_options          Java options for gatk [default:'${java_options}']
     --threads               Threads per process [default:4 for local, 16 for slurm]
-    --window                Window size passed to bedtools for gatk [default:100000]
-    --queueSize             Maximum jobs to submit to slurm [default:20]
+    --window                Window size passed to bedtools for gatk [default:${params.window}]
+    --queueSize             Maximum jobs to submit to slurm [default:${params.queueSize}}]
     --account               HPC account name for slurm sbatch, atlas and ceres requires this
     --help
 

--- a/main.nf
+++ b/main.nf
@@ -46,6 +46,18 @@ if(params.help){
   exit 0
 }
 
+def parameters_valid = ['help','outdir',
+  'genome','reads','reads_file','invariant',
+  'singularity_img','docker_img',
+  'gatk_app','bwamem2_app','samtools_app','bedtools_app','datamash_app','vcftools_app',
+  'java_options','window','queueSize','queue-size','account', 'threads'] as Set
+
+def parameter_diff = params.keySet() - parameters_valid
+if (parameter_diff.size() != 0){
+   exit 1, "[Pipeline error] Parameter(s) $parameter_diff is(are) not valid in the pipeline!\n"
+}
+
+
 if(!params.genome) {
   log.info"""
 #===============

--- a/main.nf
+++ b/main.nf
@@ -650,10 +650,10 @@ workflow {
 
   // == Since one sample may be run on multiple lanes
   i = 1
-  ireads_ch = reads_ch | map { n -> [n.get(0), n.get(1), "${i++}_"+n.get(0)] }
 
   // == Prepare mapped and unmapped read files
-  cleanreads_ch = ireads_ch
+  cleanreads_ch = reads_ch
+    | map { n -> [n.get(0), n.get(1), "${i++}_"+n.get(0)] }
     | FastqToSam
     | MarkIlluminaAdapters
     | SamToFastq


### PR DESCRIPTION
## Description

Mostly stylistic changes although I recognize the project may have moved on. 

See commit messages for details.


## Testing

```
# Create empty input files
touch R1.fasta R2.fasta genome.fasta

# Stub run
nextflow run main.nf \
 --reads "*_{R1,R2}.fasta" \
 --genome "genome.fasta" \
 -stub-run 
```

Should result in:

```
N E X T F L O W  ~  version 22.10.0
Launching `main.nf` [admiring_sammet] DSL2 - revision: e69c678c54
executor >  local (18)
[9b/ad898e] process > FastqToSam (a)                                                  [100%] 1 of 1 ✔
[da/08c0f5] process > MarkIlluminaAdapters (1_a.bam)                                  [100%] 1 of 1 ✔
[02/abac32] process > SamToFastq (1_a_marked.bam)                                     [100%] 1 of 1 ✔
[c8/eb4c5f] process > bwamem2_index (genome)                                          [100%] 1 of 1 ✔
[e7/aa2670] process > bwamem2_mem (1_a)                                               [100%] 1 of 1 ✔
[25/de9edb] process > CreateSequenceDictionary (genome)                               [100%] 1 of 1 ✔
[26/2c1cbe] process > samtools_faidx (genome)                                         [100%] 1 of 1 ✔
[51/9811cf] process > MergeBamAlignment (1_a)                                         [100%] 1 of 1 ✔
[a9/9addc8] process > bedtools_makewindows (genome)                                   [100%] 1 of 1 ✔
[ee/01ca22] process > gatk_HaplotypeCaller (1000-2000)                                [100%] 3 of 3 ✔
[c7/6ff4ce] process > merge_vcf                                                       [100%] 1 of 1 ✔
[52/e84eb5] process > vcftools_snp_only (first-round_merged.vcf)                      [100%] 1 of 1 ✔
[10/adc0c3] process > SortVcf (first-round_merged_snps-only.outputfiles)              [100%] 1 of 1 ✔
[51/254fe8] process > calc_DPvalue (first-round_merged_snps-only_sorted.vcf)          [100%] 1 of 1 ✔
[25/783131] process > VariantFiltration (first-round_merged_snps-only_sorted.vcf)     [100%] 1 of 1 ✔
[30/e770e2] process > keep_only_pass (first-round_merged_snps-only_sorted.marked.vcf) [100%] 1 of 1 ✔
Read files : [a, [/Users/jchang3/Desktop/github/Maize_WGS_Build/a_R1.fasta, /Users/jchang3/Desktop/github/Maize_WGS_Build/a_R2.fasta]] 
Genome file : /Users/jchang3/Desktop/github/Maize_WGS_Build/genome.fasta 
```